### PR TITLE
🐛 fix: changed cpp to C++ for showing colors

### DIFF
--- a/utils/langColors.js
+++ b/utils/langColors.js
@@ -193,7 +193,7 @@ const langColors = {
   NCL: '#28431f',
   Io: '#a9188d',
   Rouge: '#cc0088',
-  cpp: '#f34b7d',
+  'C++': '#f34b7d',
   'AGS Script': '#B9D9FF',
   Dogescript: '#cca760',
   nesC: '#94B0C7',


### PR DESCRIPTION
in your codebase you had `cpp` key for the C++ language repositories, but the api returns `C++` as of now so needed a minor change to that 
